### PR TITLE
[Store]Send market order request #6

### DIFF
--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -1,6 +1,7 @@
 import { createStore } from "vuex";
 import Web3 from "web3";
 import { DydxClient, SigningMethod } from "@dydxprotocol/v3-client";
+import { RootState } from "@/store/types";
 
 declare global {
   interface Window {
@@ -8,13 +9,7 @@ declare global {
   }
 }
 
-export interface State {
-  host: string;
-  ethAddress: string;
-  client?: DydxClient;
-}
-
-export default createStore<State>({
+export default createStore<RootState>({
   state: {
     host: "https://api.dydx.exchange",
     ethAddress: "",

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -14,6 +14,7 @@ export default createStore<RootState>({
     host: "https://api.dydx.exchange",
     ethAddress: "",
     client: undefined,
+    account: undefined,
   },
   getters: {
     ethAddress: (state) => {
@@ -22,6 +23,9 @@ export default createStore<RootState>({
     client: (state) => {
       return state.client;
     },
+    account: (state) => {
+      return state.account;
+    },
   },
   mutations: {
     SET_ETH_ADDRESS(state, ethAddress) {
@@ -29,6 +33,9 @@ export default createStore<RootState>({
     },
     SET_CLIENT(state, client) {
       state.client = client;
+    },
+    SET_ACCOUNT(state, account) {
+      state.account = account;
     },
   },
   actions: {
@@ -40,7 +47,7 @@ export default createStore<RootState>({
         const web3 = new Web3(window.ethereum);
 
         // eth address set
-        const accounts = await web3.eth.getAccounts();
+        const addressList = await web3.eth.getAccounts();
 
         // dydx client set
         // TODO @ts-ignore because the dependent web3 library for v3-client is out of date
@@ -52,12 +59,12 @@ export default createStore<RootState>({
         // signature & api key set
         try {
           const starkPrivateKey = await clientByWeb3.onboarding.deriveStarkKey(
-            accounts[0],
+            addressList[0],
             SigningMethod.MetaMask
           );
           const apiKeyCredentials =
             await clientByWeb3.onboarding.recoverDefaultApiCredentials(
-              accounts[0],
+              addressList[0],
               SigningMethod.MetaMask
             );
 
@@ -67,8 +74,13 @@ export default createStore<RootState>({
             starkPrivateKey,
           });
 
-          commit("SET_ETH_ADDRESS", accounts[0]);
+          const { account } = await clientByApiKey.private.getAccount(
+            addressList[0]
+          );
+
+          commit("SET_ETH_ADDRESS", addressList[0]);
           commit("SET_CLIENT", clientByApiKey);
+          commit("SET_ACCOUNT", account);
         } catch (error) {
           console.log(error);
         }

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -1,7 +1,8 @@
 import { createStore } from "vuex";
 import Web3 from "web3";
-import { DydxClient, SigningMethod } from "@dydxprotocol/v3-client";
-import { RootState } from "@/store/types";
+import { DydxClient, Market, SigningMethod } from "@dydxprotocol/v3-client";
+import { RootState, initMarketParam } from "@/store/types";
+import { MarketsStoreModule } from "@/store/modules/market";
 import { OrderbookStoreModule } from "@/store/modules/orderbook";
 
 declare global {
@@ -87,8 +88,16 @@ export default createStore<RootState>({
         }
       }
     },
+    async initMarket({ commit, dispatch, state }, { market }: initMarketParam) {
+      console.log("initMarket");
+      if (!state.client) return;
+
+      dispatch("market/init", { market: market });
+      dispatch("orderbook/init", { market: market });
+    },
   },
   modules: {
+    market: MarketsStoreModule,
     orderbook: OrderbookStoreModule,
   },
 });

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -2,6 +2,7 @@ import { createStore } from "vuex";
 import Web3 from "web3";
 import { DydxClient, SigningMethod } from "@dydxprotocol/v3-client";
 import { RootState } from "@/store/types";
+import { OrderbookStoreModule } from "@/store/modules/orderbook";
 
 declare global {
   interface Window {
@@ -87,5 +88,7 @@ export default createStore<RootState>({
       }
     },
   },
-  modules: {},
+  modules: {
+    orderbook: OrderbookStoreModule,
+  },
 });

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -3,6 +3,7 @@ import Web3 from "web3";
 import { DydxClient, Market, SigningMethod } from "@dydxprotocol/v3-client";
 import { RootState, initMarketParam } from "@/store/types";
 import { MarketsStoreModule } from "@/store/modules/market";
+import { OrderStoreModule } from "@/store/modules/order";
 import { OrderbookStoreModule } from "@/store/modules/orderbook";
 
 declare global {
@@ -98,6 +99,7 @@ export default createStore<RootState>({
   },
   modules: {
     market: MarketsStoreModule,
+    order: OrderStoreModule,
     orderbook: OrderbookStoreModule,
   },
 });

--- a/app/src/store/lib/ws/orderbook.ts
+++ b/app/src/store/lib/ws/orderbook.ts
@@ -1,0 +1,244 @@
+import { DydxClient, Market } from "@dydxprotocol/v3-client";
+
+const WS_HOST = "wss://api.dydx.exchange/v3/ws";
+
+export enum RequestMethod {
+  POST = "POST",
+  PUT = "PUT",
+  GET = "GET",
+  DELETE = "DELETE",
+}
+
+enum ORDER_BOOK_VALUE {
+  PRICE,
+  SIZE,
+  UPDATE_TIME,
+}
+
+class DydxOrderBook {
+  orderbook: {
+    bids: [size: number, size: number, updateTime: number][];
+    asks: [size: number, size: number, updateTime: number][];
+  };
+  client: DydxClient;
+  symbol: Market;
+  updateCallback: () => void;
+  isConnected: boolean;
+  maxDepth: number;
+
+  constructor(
+    client: DydxClient,
+    maxDepth: number,
+    symbol: Market,
+    updateCallback: () => void
+  ) {
+    this.client = client;
+    this.symbol = symbol;
+    this.maxDepth = maxDepth;
+    this.orderbook = { bids: [], asks: [] };
+    this.updateCallback = updateCallback;
+    this.isConnected = false;
+  }
+
+  public async start() {
+    await this.connect(this.client, this.symbol);
+  }
+
+  public get bestPrice() {
+    return {
+      ask: this.orderbook.asks.length ? this.orderbook.asks[0] : [],
+      bid: this.orderbook.bids.length ? this.orderbook.bids[0] : [],
+    };
+  }
+
+  private async initOrderBook(contents: {
+    bids: [{ price: string; size: string; offset: string }];
+    asks: [{ price: string; size: string; offset: string }];
+  }) {
+    const orderbook: {
+      bids: [size: number, size: number, updateTime: number][];
+      asks: [size: number, size: number, updateTime: number][];
+    } = { bids: [], asks: [] };
+    contents.asks.forEach((ask) => {
+      if (Number(ask.size) !== 0) {
+        orderbook.asks.push([
+          Number(ask.price),
+          Number(ask.size),
+          Number(ask.offset),
+        ]);
+      }
+    });
+    contents.bids.forEach((bid) => {
+      if (Number(bid.size) !== 0) {
+        orderbook.asks.push([
+          Number(bid.price),
+          Number(bid.size),
+          Number(bid.offset),
+        ]);
+      }
+    });
+
+    this.orderbook = orderbook;
+  }
+
+  private async updateOrderBook(contents: {
+    offset: string;
+    bids: [];
+    asks: [];
+  }) {
+    const orderbook = { ...this.orderbook };
+    const offset = Number(contents.offset);
+
+    // ask
+    let askMinPrice = Number.MAX_VALUE;
+    contents.asks.forEach((ask) => {
+      const price = Number(ask[0]);
+      const size = Number(ask[1]);
+
+      const targetIndex = orderbook.asks.findIndex(
+        (ask) => ask[ORDER_BOOK_VALUE.PRICE] === price
+      );
+
+      if (size === 0) {
+        // delete
+        if (targetIndex !== -1) {
+          if (
+            orderbook.asks[targetIndex][ORDER_BOOK_VALUE.UPDATE_TIME] < offset
+          ) {
+            orderbook.asks.splice(targetIndex, 1);
+          }
+        }
+      } else {
+        if (targetIndex !== -1) {
+          // replace
+          if (
+            orderbook.asks[targetIndex][ORDER_BOOK_VALUE.UPDATE_TIME] < offset
+          ) {
+            orderbook.asks.splice(targetIndex, 1, [price, size, offset]);
+          }
+        } else {
+          // insert
+          orderbook.asks.push([price, size, offset]);
+        }
+      }
+
+      if (size !== 0 && askMinPrice > price) {
+        askMinPrice = price;
+      }
+    });
+
+    // bid
+    let bidMaxPrice = 0;
+    contents.bids.forEach((bid) => {
+      const price = Number(bid[0]);
+      const size = Number(bid[1]);
+
+      const targetIndex = orderbook.bids.findIndex(
+        (bid) => bid[ORDER_BOOK_VALUE.PRICE] === price
+      );
+
+      if (size === 0) {
+        // delete
+        if (targetIndex !== -1) {
+          if (
+            orderbook.bids[targetIndex][ORDER_BOOK_VALUE.UPDATE_TIME] < offset
+          ) {
+            orderbook.bids.splice(targetIndex, 1);
+          }
+        }
+      } else {
+        if (targetIndex !== -1) {
+          // replace
+          if (
+            orderbook.bids[targetIndex][ORDER_BOOK_VALUE.UPDATE_TIME] < offset
+          ) {
+            orderbook.bids.splice(targetIndex, 1, [price, size, offset]);
+          }
+        } else {
+          // insert
+          orderbook.bids.push([price, size, offset]);
+        }
+      }
+
+      if (size !== 0 && bidMaxPrice < price) {
+        bidMaxPrice = price;
+      }
+    });
+
+    // sort
+    orderbook.asks.sort(
+      (a, b) => a[ORDER_BOOK_VALUE.PRICE] - b[ORDER_BOOK_VALUE.PRICE]
+    );
+    orderbook.bids.sort(
+      (a, b) => b[ORDER_BOOK_VALUE.PRICE] - a[ORDER_BOOK_VALUE.PRICE]
+    );
+
+    // fix
+    if (orderbook.bids.length && orderbook.asks.length) {
+      const askValidOrderIndex = orderbook.asks.findIndex(
+        (ask) => ask[ORDER_BOOK_VALUE.PRICE] > bidMaxPrice
+      );
+      const bidValidOrderIndex = orderbook.bids.findIndex(
+        (bid) => bid[ORDER_BOOK_VALUE.PRICE] < askMinPrice
+      );
+      orderbook.asks.splice(0, askValidOrderIndex);
+      orderbook.bids.splice(0, bidValidOrderIndex);
+    }
+
+    // trim
+    orderbook.asks.splice(this.maxDepth);
+    orderbook.bids.splice(this.maxDepth);
+
+    this.orderbook = orderbook;
+
+    this.isConnected = true;
+  }
+
+  private async connect(client: DydxClient, symbol: Market) {
+    const msg = {
+      type: "subscribe",
+      channel: "v3_orderbook",
+      id: symbol,
+      includeOffsets: true,
+    };
+
+    const ws = new WebSocket(WS_HOST);
+
+    ws.onopen = () => {
+      console.log("orderbook ws open");
+      ws.send(JSON.stringify(msg));
+    };
+
+    ws.onmessage = (message) => {
+      const data = JSON.parse(message.data);
+      if (data.type == "subscribed") {
+        this.initOrderBook(data.contents);
+      } else if (data.type == "channel_data") {
+        this.updateOrderBook(data.contents);
+      } else {
+        console.log(data);
+      }
+      this.updateCallback();
+    };
+
+    ws.onerror = (error) => {
+      console.log("orderbook ws error");
+      console.log(error);
+      ws.close();
+      this.isConnected = false;
+      this.updateCallback();
+    };
+
+    ws.onclose = () => {
+      console.log("orderbook ws closed");
+      this.isConnected = false;
+      // 3s wait and reconnect
+      setTimeout(() => {
+        this.connect(this.client, this.symbol);
+      }, 3000);
+      this.updateCallback();
+    };
+  }
+}
+
+export { ORDER_BOOK_VALUE, DydxOrderBook };

--- a/app/src/store/modules/market.ts
+++ b/app/src/store/modules/market.ts
@@ -1,0 +1,44 @@
+import { Module } from "vuex";
+import { RootState, MarketsState, initMarketParam } from "@/store/types";
+
+export const MarketsStoreModule: Module<MarketsState, RootState> = {
+  namespaced: true,
+  state: {
+    marketInfo: undefined,
+  },
+  getters: {
+    marketInfo: (state) => {
+      return state.marketInfo;
+    },
+    priceDicimalPoint: (state) => {
+      if (!state.marketInfo) return undefined;
+      const numbers = state.marketInfo.tickSize.split(".");
+      return numbers[1] ? numbers[1].length : 0;
+    },
+    stepSize: (state) => {
+      if (!state.marketInfo) return undefined;
+      return Number(state.marketInfo.stepSize);
+    },
+    minOrderSize: (state) => {
+      if (!state.marketInfo) return undefined;
+      return Number(state.marketInfo.minOrderSize);
+    },
+  },
+  mutations: {
+    SET_MARKETS(state, marketInfo) {
+      state.marketInfo = marketInfo;
+    },
+  },
+  actions: {
+    async init({ commit, rootState }, { market }: initMarketParam) {
+      console.log("markets init");
+      if (!rootState.client) return;
+
+      const { markets } = await rootState.client.public.getMarkets(market);
+      console.log(markets[market]);
+
+      commit("SET_MARKETS", markets[market]);
+    },
+  },
+  modules: {},
+};

--- a/app/src/store/modules/order.ts
+++ b/app/src/store/modules/order.ts
@@ -1,0 +1,56 @@
+import { Module } from "vuex";
+import { OrderSide, OrderType, TimeInForce } from "@dydxprotocol/v3-client";
+import { RootState, OrderState, MarketOrderParam } from "@/store/types";
+
+export const OrderStoreModule: Module<OrderState, RootState> = {
+  namespaced: true,
+  state: {},
+  getters: {},
+  mutations: {},
+  actions: {
+    async marketOrder(
+      { commit, rootState, rootGetters },
+      { market, side, size }: MarketOrderParam
+    ) {
+      console.log("marketOrder");
+      if (!rootState.client || !rootState.account) return;
+      if (
+        !rootGetters["orderbook/isConnected"] ||
+        !rootGetters["market/marketInfo"]
+      )
+        return;
+      if (size < rootGetters["market/minOrderSize"]) return;
+
+      const priceDicimalPoint: number = rootGetters["market/priceDicimalPoint"];
+      let orderPrice = "";
+      if (side === OrderSide.BUY) {
+        const bestPrice: number = rootGetters["orderbook/bestAskPrice"];
+        orderPrice = (bestPrice + bestPrice * 0.1).toFixed(priceDicimalPoint);
+      } else {
+        const bestPrice: number = rootGetters["orderbook/bestBidPrice"];
+        orderPrice = (bestPrice - bestPrice * 0.1).toFixed(priceDicimalPoint);
+      }
+
+      const stepSize: number = rootGetters["market/stepSize"];
+      const orderSize = String(Math.trunc(size / stepSize) * stepSize);
+
+      const param = {
+        type: OrderType.MARKET,
+        market: market,
+        side: side,
+        size: orderSize,
+        price: orderPrice,
+        timeInForce: TimeInForce.FOK, // dummy param
+        postOnly: false, // dummy param
+        limitFee: "0.05", // dummy param
+        expiration: new Date(Date.now() + 600000).toISOString(), // dummy param
+      };
+      const res = await rootState.client.private.createOrder(
+        param,
+        rootState.account.positionId
+      );
+      console.log(res);
+    },
+  },
+  modules: {},
+};

--- a/app/src/store/modules/orderbook.ts
+++ b/app/src/store/modules/orderbook.ts
@@ -1,0 +1,67 @@
+import { Module } from "vuex";
+import { RootState, OrderbookState, initOrderbookParam } from "@/store/types";
+import {
+  DydxOrderBook,
+  ORDER_BOOK_VALUE as DYDX_BOOK_VALUE,
+} from "@/store/lib/ws/orderbook";
+
+export const OrderbookStoreModule: Module<OrderbookState, RootState> = {
+  namespaced: true,
+  state: {
+    dydxOrderBook: undefined,
+    isConnected: false,
+    symbol: undefined,
+    bestAskPrice: undefined,
+    bestBidPrice: undefined,
+  },
+  getters: {
+    symbol: (state) => {
+      return state.symbol;
+    },
+    isConnected: (state) => {
+      return state.isConnected;
+    },
+    bestAskPrice: (state) => {
+      return state.bestAskPrice;
+    },
+    bestBidPrice: (state) => {
+      return state.bestBidPrice;
+    },
+  },
+  mutations: {
+    SET_DYDX_ORDERBOOK(state, dydxOrderBook) {
+      state.dydxOrderBook = dydxOrderBook;
+    },
+    UPDATE_ORDERBOOK(state) {
+      if (!state.dydxOrderBook) return;
+      state.symbol = state.dydxOrderBook.symbol;
+      state.isConnected = state.dydxOrderBook.isConnected;
+      if (state.dydxOrderBook.bestPrice.ask.length) {
+        state.bestAskPrice =
+          state.dydxOrderBook.bestPrice.ask[DYDX_BOOK_VALUE.PRICE];
+      }
+      if (state.dydxOrderBook.bestPrice.bid.length) {
+        state.bestBidPrice =
+          state.dydxOrderBook.bestPrice.bid[DYDX_BOOK_VALUE.PRICE];
+      }
+    },
+  },
+  actions: {
+    async init({ commit, rootState }, { market }: initOrderbookParam) {
+      console.log("orderbook init");
+      if (!rootState.client) return;
+      const dydxOrderBook = new DydxOrderBook(
+        rootState.client,
+        1000,
+        market,
+        () => {
+          commit("UPDATE_ORDERBOOK");
+        }
+      );
+      await dydxOrderBook.start();
+
+      commit("SET_DYDX_ORDERBOOK", dydxOrderBook);
+    },
+  },
+  modules: {},
+};

--- a/app/src/store/modules/orderbook.ts
+++ b/app/src/store/modules/orderbook.ts
@@ -1,5 +1,5 @@
 import { Module } from "vuex";
-import { RootState, OrderbookState, initOrderbookParam } from "@/store/types";
+import { RootState, OrderbookState, initMarketParam } from "@/store/types";
 import {
   DydxOrderBook,
   ORDER_BOOK_VALUE as DYDX_BOOK_VALUE,
@@ -47,7 +47,7 @@ export const OrderbookStoreModule: Module<OrderbookState, RootState> = {
     },
   },
   actions: {
-    async init({ commit, rootState }, { market }: initOrderbookParam) {
+    async init({ commit, rootState }, { market }: initMarketParam) {
       console.log("orderbook init");
       if (!rootState.client) return;
       const dydxOrderBook = new DydxOrderBook(

--- a/app/src/store/types.ts
+++ b/app/src/store/types.ts
@@ -1,0 +1,37 @@
+import {
+  DydxClient,
+  AccountResponseObject,
+  OrderSide,
+  Market,
+} from "@dydxprotocol/v3-client";
+import {
+  DydxOrderBook,
+  ORDER_BOOK_VALUE as DYDX_BOOK_VALUE,
+} from "@/store/lib/ws/orderbook";
+
+export interface RootState {
+  host: string;
+  ethAddress: string;
+  client?: DydxClient;
+  account?: AccountResponseObject;
+}
+
+export interface OrderState {}
+
+export interface OrderbookState {
+  dydxOrderBook?: DydxOrderBook;
+  isConnected: boolean;
+  symbol?: Market;
+  bestAskPrice?: number;
+  bestBidPrice?: number;
+}
+
+export interface MarketOrderParam {
+  market: Market;
+  side: OrderSide;
+  size: string;
+}
+
+export interface initOrderbookParam {
+  market: Market;
+}

--- a/app/src/store/types.ts
+++ b/app/src/store/types.ts
@@ -35,9 +35,5 @@ export interface OrderbookState {
 export interface MarketOrderParam {
   market: Market;
   side: OrderSide;
-  size: string;
-}
-
-export interface initOrderbookParam {
-  market: Market;
+  size: number;
 }

--- a/app/src/store/types.ts
+++ b/app/src/store/types.ts
@@ -3,17 +3,23 @@ import {
   AccountResponseObject,
   OrderSide,
   Market,
+  MarketResponseObject,
 } from "@dydxprotocol/v3-client";
-import {
-  DydxOrderBook,
-  ORDER_BOOK_VALUE as DYDX_BOOK_VALUE,
-} from "@/store/lib/ws/orderbook";
+import { DydxOrderBook } from "@/store/lib/ws/orderbook";
 
 export interface RootState {
   host: string;
   ethAddress: string;
   client?: DydxClient;
   account?: AccountResponseObject;
+}
+
+export interface MarketsState {
+  marketInfo?: MarketResponseObject;
+}
+
+export interface initMarketParam {
+  market: Market;
 }
 
 export interface OrderState {}


### PR DESCRIPTION
#### 対応内容
* Stateの型定義を別ファイルに外出し
* 認証処理にアカウント情報を取得する処理を追加
* 板情報をwebsocketでリアルタイム生成するstoreを追加
* マーケット情報を取得するstoreを追加
* 注文用storeを追加
   * 成行注文のみ

#### 使い方
認証処理
```
dispatch("initClient")
``` 

対象通貨の情報取得開始
```
dispatch("initMarket", { market: Market.BTC_USD })
``` 

成行注文
```
dispatch("order/marketOrder", {
        market: Market.BTC_USD,
        side: OrderSide.BUY,
        size: 0.001,
      });
``` 

https://github.com/yusakapon/dydx-chrome-extension/issues/6