### PR TITLE
Fix to activate even when not transitioning to the trade page #45

### DIFF
--- a/app/src/components/TradeHeader.vue
+++ b/app/src/components/TradeHeader.vue
@@ -15,26 +15,15 @@ const bestBidPrice = computed(() => store.getters["orderbook/bestBidPrice"]);
 const emit = defineEmits(["currency-pair"]);
 
 onMounted(() => {
-  const pair = getUrl();
-  if (pair) {
-    selectedPairs.value = pair;
-    emit("currency-pair", selectedPairs.value);
-    initMarket(selectedPairs.value as keyof typeof Market);
-  }
-  const observer = new MutationObserver(() => {
-    const pair = getUrl();
-    if (pair && pair !== selectedPairs.value) {
-      selectedPairs.value = pair;
-      emit("currency-pair", selectedPairs.value);
-      initMarket(selectedPairs.value as keyof typeof Market);
-    }
-  });
-  observer.observe(document, { childList: true, subtree: true });
+  const pair = getPairFromUrl();
+  selectedPairs.value = pair;
+  emit("currency-pair", selectedPairs.value);
+  initMarket(selectedPairs.value as keyof typeof Market);
 });
 
 const changeCurrency = (event: Event) => {
-  const value = (event.target as HTMLInputElement).value;
-  setUrl(value);
+  emit("currency-pair", selectedPairs.value);
+  initMarket(selectedPairs.value as keyof typeof Market);
 };
 
 const initMarket = async (market: keyof typeof Market) => {
@@ -43,9 +32,11 @@ const initMarket = async (market: keyof typeof Market) => {
   });
 };
 
-const getUrl = () => {
+const getPairFromUrl = () => {
   const url = location.pathname;
-  const pair = url.split("/").slice(-1)[0].replace("-", "_");
+  const splitUrl = url.split("/");
+  if (splitUrl[1] !== "trade") return "BTC_USD";
+  const pair = splitUrl[2].replace("-", "_");
   return pair;
 };
 

--- a/app/src/manifest.json
+++ b/app/src/manifest.json
@@ -6,8 +6,8 @@
   "content_scripts": [
     {
       "matches": [
-        "https://trade.dydx.exchange/trade/*",
-        "https://trade.stage.dydx.exchange/trade/*"
+        "https://trade.dydx.exchange/*",
+        "https://trade.stage.dydx.exchange/*"
       ],
       "js": ["loader.js"],
       "css": ["css/app.css"]


### PR DESCRIPTION
#### 対応内容
* `/trade`に直遷移した時しか起動しなかったので他のページに遷移してきた場合にも起動するよう修正
* tardeページ以外に遷移したときはデフォルトBTC-USD
* URLとの連動をなくして全ページで使用できるようにした

https://github.com/yusakapon/dydx-chrome-extension/issues/45