### PR TITLE
Fix to allow editing of orders #53

### DIFF
--- a/app/src/store/types.ts
+++ b/app/src/store/types.ts
@@ -84,6 +84,11 @@ export interface LimitOrderParam {
   expireSecond: number;
 }
 
+export interface EditOrderParam {
+  orderId: string;
+  price: number;
+}
+
 export interface CancelAllParam {
   market?: Market;
 }


### PR DESCRIPTION
#### 対応内容
* 注文を編集できるactionを追加した
* UI部分は[別Issue](https://github.com/yusakapon/dydx-chrome-extension/issues/66)立てました

```
// example
store.dispatch("order/editOrder", {
    orderId: "xxxxx",
    price: 100000,
  });
```

https://github.com/yusakapon/dydx-chrome-extension/issues/53