### PR TITLE
Reloading on a 1inch trade page causes an error #98

### DIFF
--- a/app/src/components/TradeHeader.vue
+++ b/app/src/components/TradeHeader.vue
@@ -56,7 +56,8 @@ const getPairFromUrl = () => {
   const url = location.pathname;
   const splitUrl = url.split("/");
   if (splitUrl[1] !== "trade") return "BTC_USD";
-  const pair = splitUrl[2].replace("-", "_");
+  let pair = splitUrl[2].replace("-", "_");
+  pair = pair.replace("1INCH", "ONEINCH");
   return pair;
 };
 </script>


### PR DESCRIPTION
#### 対応内容
* ちょっと無理やりやけど、1INCH-> ONEINCHに変換するようにした

https://github.com/yusakapon/dydx-chrome-extension/issues/98